### PR TITLE
fix read interactor error reporting

### DIFF
--- a/app/src/main/java/com/javahelp/frontend/gateway/LambdaRegisterDataAccess.java
+++ b/app/src/main/java/com/javahelp/frontend/gateway/LambdaRegisterDataAccess.java
@@ -113,12 +113,20 @@ public class LambdaRegisterDataAccess extends RESTAPIGateway<RegisterResult> imp
 
             @Override
             public RegisterResult get() throws ExecutionException, InterruptedException {
-                return response.get().get();
+                RESTAPIGatewayResponse<RegisterResult> result = response.get();
+                if (!result.isSuccess()) {
+                    return new RegisterResult(result.getErrorMessage());
+                }
+                return result.get();
             }
 
             @Override
             public RegisterResult get(long l, TimeUnit timeUnit) throws ExecutionException, InterruptedException, TimeoutException {
-                return response.get(l, timeUnit).get();
+                RESTAPIGatewayResponse<RegisterResult> result = response.get(l, timeUnit);
+                if (!result.isSuccess()) {
+                    return new RegisterResult(result.getErrorMessage());
+                }
+                return result.get();
             }
         };
     }

--- a/app/src/test/java/com/javahelp/frontend/domain/user/read/ReadInteractorTest.java
+++ b/app/src/test/java/com/javahelp/frontend/domain/user/read/ReadInteractorTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.javahelp.frontend.domain.user.delete.DeleteResult;
 import com.javahelp.frontend.domain.user.delete.IDeleteDataAccess;
 import com.javahelp.frontend.domain.user.login.ILoginDataAccess;
 import com.javahelp.frontend.domain.user.login.ISaltDataAccess;
@@ -109,7 +110,7 @@ public class ReadInteractorTest {
             assertEquals(u.getStringID(), readUser.getStringID());
         } finally {
             if (u != null && t != null) {
-                new LambdaDeleteDataAccess(new IAuthInformationProvider() {
+                DeleteResult r = new LambdaDeleteDataAccess(new IAuthInformationProvider() {
                     @Override
                     public String getUserID() {
                         return u.getStringID();


### PR DESCRIPTION
This PR fixes the `ReadInteractorTest` by better reporting errors within the `RegisterInteractor`. Specifically if a response comes back, but no `User` is created, the `RegisterInteractor` now bundles the error from the `InternalRESTAPIGatewayResponse<RegisterResult>` into the `RegisterResult` returned by the `Future`.